### PR TITLE
Add package.json ready for npm deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "macrovich",
+  "version": "0.2.0",
+  "description": "A set of three macros to ease writing `*.cljc` supporting Clojure, Clojurescript and self-hosted Clojurescript.",
+  "author": "Christophe Grand",
+  "homepage": "https://github.com/cgrand/macrovich",
+  "license": "EPL-1.0",
+  "directories": {
+    "lib": "src",
+    "cache": "./lumo-cache"
+  },
+  "keywords": [
+    "cljs",
+    "self-host",
+    "macro"
+  ]
+}


### PR DESCRIPTION
Lumo has experimental support for ClojureScript npm packaging now:
  https://github.com/anmonteiro/lumo/issues/130

This means we can deploy to npm seamlessly and then require namespaces at the
REPL. Macrovich is massively important for converting JVM ClojureScript to
self-host ClojureScript so I think it should be the first one who gets this new
approach so that it can be used as npm dependency as well.