### PR TITLE
Add files directive to package.json and remove cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "homepage": "https://github.com/cgrand/macrovich",
   "license": "EPL-1.0",
   "directories": {
-    "lib": "src",
-    "cache": "./lumo-cache"
+    "lib": "src"
   },
+  "files": [
+    "src/*"
+  ],
   "keywords": [
     "cljs",
     "cljc",


### PR DESCRIPTION
This restricts what goes into the npm tarball to only src. Additionally we
remove the cache key from directories as it is not yet utilized by lumo.